### PR TITLE
Add cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ bin/*
 win32/ehata/*.aps
 win32/ehata/Debug/*
 win32/ehata/Release/*
+win32/ehata/x64/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+set(CMAKE_CXX_COMPILER "clang++")
+
+project(ehata)
+
+# C++14
+set(CMAKE_CXX_STANDARD 14)
+
+# Headers
+include_directories(include)
+
+# SRC
+file(GLOB SOURCES "src/*.cpp")
+
+# Shared Library
+add_library(ehata SHARED ${SOURCES})

--- a/include/ehata.h
+++ b/include/ehata.h
@@ -6,7 +6,7 @@
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 #ifdef __linux__
-#define DLLEXPORT 
+#define DLLEXPORT extern "C"
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif

--- a/src/ExtendedHata.cpp
+++ b/src/ExtendedHata.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 
 /*
 *   Description: The Extended-Hata Urban Propagation Model
@@ -44,7 +44,7 @@ void ExtendedHata_DBG(float pfl[], float f__mhz, float h_b__meter, float h_m__me
     PreprocessTerrainPath(pfl, h_b__meter, h_m__meter, interValues);
 
     float h_m_gnd__meter, d1_hzn__km, d2_hzn__km;
-    
+
     h_m_gnd__meter = pfl[2];
     interValues->h_m_eff__meter = h_m__meter + pfl[2] - interValues->h_avg__meter[0];
     interValues->h_b_eff__meter = h_b__meter + pfl[np + 2] - interValues->h_avg__meter[1];

--- a/src/FindHorizons.cpp
+++ b/src/FindHorizons.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 
 void FindHorizons(float *pfl, float gme, float d__meter, float h_1__meter,
     float h_2__meter, float *d_hzn__meter)

--- a/src/FindQuantile.cpp
+++ b/src/FindQuantile.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 
 float FindQuantile(const int &nn, float *a, const int &ir)
 {

--- a/src/FineRollingHillyTerrainCorectionFactor.cpp
+++ b/src/FineRollingHillyTerrainCorectionFactor.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 /*
@@ -26,7 +26,7 @@ float FineRollingHillyTerrainCorectionFactor(InterValues *interValues, float h_m
         deltah_use = 10.0;
     else
         deltah_use = interValues->deltah__meter;
-        
+
     K_h = a + log10(deltah_use) * (b + c * log10(deltah_use));
 
     if (h_m_gnd__meter >= interValues->pfl10__meter)

--- a/src/GeneralSlopeCorrectionFactor.cpp
+++ b/src/GeneralSlopeCorrectionFactor.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 
 /*
 *   Description: Find the general slope correction factor

--- a/src/IsolatedRidgeCorrectionFactor.cpp
+++ b/src/IsolatedRidgeCorrectionFactor.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 /*
@@ -15,9 +15,9 @@ float IsolatedRidgeCorrectionFactor(float d1_hzn__km, float d2_hzn__km, float h_
 {
     float d_1__km[3] = { 15.0, 30.0, 60.0 };
     float d_2__km[9] = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
-    
+
     // points from Figure 31, Okumura
-    float curve_data[3][9] = 
+    float curve_data[3][9] =
             { {  4.0, -13.0, -17.5, -17.5, -15.0, -12.5, -10.0, -8.0, -6.0 },   // C curve : d1 <= 15 km
               { 12.0,  -8.5, -13.0, -12.0, -10.0,  -8.0,  -6.5, -5.0, -4.0 },   // B curve : d1 <= 30 km
               { 20.0,  -4.0,  -6.5,  -6.0,  -4.5,  -3.5,  -2.5, -2.0, -1.0 } }; // A curve : d1 <= 60 km

--- a/src/LeastSquares.cpp
+++ b/src/LeastSquares.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 /*

--- a/src/MedianBasicPropLoss.cpp
+++ b/src/MedianBasicPropLoss.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 void MedianBasicPropLoss(float f__mhz, float h_b__meter, float h_m__meter, float d__km, int enviro_code, float* plb_med__db, InterValues *interValues)
@@ -8,7 +8,7 @@ void MedianBasicPropLoss(float f__mhz, float h_b__meter, float h_m__meter, float
     double c = 1.0 / sqrt(eps*perm);
 
     //	Extend the frequency range to 3, 000 MHz.This is done by computing alpha_1, beta_1, and gamma_1
-    //		in Okumura et al.'s median reference attenuation equation in an urban environment.  
+    //		in Okumura et al.'s median reference attenuation equation in an urban environment.
     //	Solve the 3 simultanious equations :
     //		- A-4a: 22    dB @ 1500 MHz at 1 km
     //		- A-4b: 23.5  db @ 2000 MHZ at 1 km
@@ -93,19 +93,19 @@ void MedianBasicPropLoss(float f__mhz, float h_b__meter, float h_m__meter, float
         interValues->trace_code = interValues->trace_code | TRACE__METHOD_11;
     }
 
-    if (enviro_code == 23 || enviro_code == 24) 
+    if (enviro_code == 23 || enviro_code == 24)
     {
         *plb_med__db = plb_urban;
 
         interValues->trace_code = interValues->trace_code | TRACE__METHOD_12;
-    } 
-    else if (enviro_code == 22) 
+    }
+    else if (enviro_code == 22)
     {
         *plb_med__db = plb_urban - suburban_factor;
 
         interValues->trace_code = interValues->trace_code | TRACE__METHOD_13;
     }
-    else 
+    else
     {
         *plb_med__db = plb_urban - rural_factor;
 

--- a/src/MedianRollingHillyTerrainCorrectionFactor.cpp
+++ b/src/MedianRollingHillyTerrainCorrectionFactor.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 /*

--- a/src/MixedPathCorrectionFactor.cpp
+++ b/src/MixedPathCorrectionFactor.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 
 /*
 *   Description: Find the correction factor for mixed land-sea path

--- a/src/PreprocessTerrainPath.cpp
+++ b/src/PreprocessTerrainPath.cpp
@@ -1,4 +1,4 @@
-#include "ehata.h"
+#include "../include/ehata.h"
 #include "math.h"
 
 void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, InterValues *interValues)
@@ -22,7 +22,7 @@ void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, Inter
 *                - pfl[1] = step size, in meters
 *                - pfl[i] = elevation above mean sea level, in meters
 *   Outputs:
-*       interValues->h_avg__meter : Average ground height of each terminal 
+*       interValues->h_avg__meter : Average ground height of each terminal
 *               above sea level, in meters
 *                - h_avg__meter[0] = terminal at start of pfl
 *                - h_avg__meter[1] = terminal at end of pfl
@@ -52,7 +52,7 @@ void FindAverageGroundHeight(float *pfl, InterValues *interValues)
         for (int i = i_start; i <= i_end; i++)
             sum = sum + pfl[i];
         interValues->h_avg__meter[0] = sum / (i_end - i_start + 1) * (d__km - 3.0) / 12.0;
-        
+
         i_start = 2;
         i_end = np + 2 - int(3.0 / xi);
         sum = 0.0;
@@ -174,7 +174,7 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
     interValues->slope_min = 1.0e+31;
     float slope_five = 0.0;
     float slope;
-    
+
     float x1, x2;
     float pfl_segment[400] = { 0 };
 
@@ -185,7 +185,7 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
         int npts = x2 / xi;
         pfl_segment[0] = npts;
         pfl_segment[1] = xi;
-        for (int i = 0; i < npts + 1; i++) 
+        for (int i = 0; i < npts + 1; i++)
             pfl_segment[i + 2] = pfl[i + 2];
 
         float z1 = 0, z2 = 0;

--- a/win32/ehata/ehata.vcxproj
+++ b/win32/ehata/ehata.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\ehata.h" />
+    <ClInclude Include="..\..\include\ehata.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
@@ -68,7 +68,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -91,17 +91,20 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\bin\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\build\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\bin\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\build\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -130,6 +133,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;EHATA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -168,10 +172,13 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <Optimization>Disabled</Optimization>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;EHATA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
As it stood, the EHata repository did not provide comfortable support to Unix users. Noticing this, I added a `CMakeLists.txt` file so that Unix users can use CMake to easily compile this library. With this, I made the appropriate `#define DLLEXPORT` statement for Linux users.

Now, all a Unix user has to perform, in the terminal, to get the compiled library is:
```
$ cd build
$ cmake ..
$ make
```
and the library, `libehata.so`, will be located in the `build` folder.

In addition, I also separated the header file, `ehata.h`, into a new `include` folder; this change to the path is reflected in the source code. The reason for this change is to mimic modern C/C++ folder structures.

NONE of the algorithms or math were changed.