### PR TITLE
RPM build on CentOS 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,15 @@ file(GLOB SOURCES "src/*.cpp")
 
 # Shared Library
 add_library(ehata SHARED ${SOURCES})
+
+install(
+    TARGETS ehata
+    LIBRARY DESTINATION "lib${LIB_SUFFIX}"
+    COMPONENT ehata
+)
+
+install(
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/ehata.h"
+    DESTINATION "include/ehata"
+    COMPONENT ehata-dev
+)

--- a/ehata.spec
+++ b/ehata.spec
@@ -1,0 +1,42 @@
+Name:		ehata
+Version:	3.1.0.0
+Release:	1%{?dist}
+Summary:	Extended Hata (eHata) Urban Propagation Model
+
+Group:		Development/Libraries
+License:	public domain
+URL:		https://github.com/NTIA/ehata
+#git archive --format=tar.gz -o ehata-3.1.0.0.tar.gz --prefix=ehata-3.1.0.0/ master
+Source0:	https://github.com/NTIA/ehata/archive/master.tar.gz?prefix=ehata-3.1.0.0;o=./ehata-3.1.0.0.tar.gz
+
+BuildRequires:	clang
+#Requires:	
+
+%description
+The Extended Hata (eHata) Urban Propagation Model - This code repository
+contains a C++ reference version of the eHata urban propagation model. The model
+was developed by NTIA and used in NTIA Technical Report TR-15-517, "3.5 GHz
+Exclusion Zone Analyses and Methodology".
+
+%prep
+%setup -q
+
+%build
+pushd build
+cmake3 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_DOCS=YES -DBUILD_SHARED_LIBS=true -DLIB_SUFFIX=64 ..
+make %{?_smp_mflags}
+popd
+
+%install
+pushd build
+make install DESTDIR=%{buildroot}
+popd
+
+
+%files
+%doc
+
+
+
+%changelog
+

--- a/ehata.spec
+++ b/ehata.spec
@@ -10,7 +10,12 @@ URL:		https://github.com/NTIA/ehata
 Source0:	https://github.com/NTIA/ehata/archive/master.tar.gz?prefix=ehata-3.1.0.0;o=./ehata-3.1.0.0.tar.gz
 
 BuildRequires:	clang
+BuildRequires:	cmake3
 #Requires:	
+
+%package devel
+Summary:	Extended Hata (eHata) Urban Propagation Model Header File
+Requires:	%{name} = %{version}
 
 %description
 The Extended Hata (eHata) Urban Propagation Model - This code repository
@@ -18,25 +23,30 @@ contains a C++ reference version of the eHata urban propagation model. The model
 was developed by NTIA and used in NTIA Technical Report TR-15-517, "3.5 GHz
 Exclusion Zone Analyses and Methodology".
 
+%description devel
+Extended Hata (eHata) Urban Propagation Model Header File
+
 %prep
 %setup -q
 
 %build
 pushd build
-cmake3 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_DOCS=YES -DBUILD_SHARED_LIBS=true -DLIB_SUFFIX=64 ..
+cmake3 -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=true -DLIB_SUFFIX=64 ..
 make %{?_smp_mflags}
 popd
 
 %install
 pushd build
-make install DESTDIR=%{buildroot}
+make install DESTDIR=%{buildroot} LIB_SUFFIX=64
 popd
 
-
 %files
-%doc
+%defattr(0644,root,root,-)
+%{_libdir}/libehata.so
 
-
+%files devel
+%defattr(0644,root,root,-)
+%{_includedir}/ehata/ehata.h
 
 %changelog
 


### PR DESCRIPTION
I updated CMakeLists.txt to add install directives and I added RPM spec file ehata.spec to build RPMs on CentOS7.  
 
      - ehata-3.1.0.0-1.el7.mrdvt92.x86_64.rpm
      - ehata-devel-3.1.0.0-1.el7.mrdvt92.x86_64.rpm

To Build RPM

```
[temp]$ git clone https://github.com/mrdvt92/ehata.git
[temp]$ cd ehata/
[ehata]$ git archive --format=tar.gz -o ehata-3.1.0.0.tar.gz --prefix=ehata-3.1.0.0/ master
[ehata]$ rpmbuild -ta ehata-3.1.0.0.tar.gz
...
Wrote: ~/rpmbuild/SRPMS/ehata-3.1.0.0-1.el7.mrdvt92.src.rpm
Wrote: ~/rpmbuild/RPMS/x86_64/ehata-3.1.0.0-1.el7.mrdvt92.x86_64.rpm
Wrote: ~/rpmbuild/RPMS/x86_64/ehata-devel-3.1.0.0-1.el7.mrdvt92.x86_64.rpm
```